### PR TITLE
fixes for building on OS X

### DIFF
--- a/egs/vystadial/online_demo/path.sh
+++ b/egs/vystadial/online_demo/path.sh
@@ -30,6 +30,7 @@ openfst=`pwd`/../../../tools/openfst/
 
 export PATH=$kaldisrc/bin:$kaldisrc/fgmmbin:$kaldisrc/gmmbin:$kaldisrc/nnetbin:$kaldisrc/sgmm2bin:$kaldisrc/tiedbin:$kaldisrc/featbin:$kaldisrc/fstbin:$kaldisrc/latbin:$kaldisrc/onlinebin:$kaldisrc/sgmmbin:$kaldisrc/onl-rec:$openfst/bin:"$PATH"
 export LD_LIBRARY_PATH=$kaldisrc/onl-rec:$kaldisrc/pykaldi/kaldi:$openfst/lib:$openfst/lib/fst:$LD_LIBRARY_PATH
+export DYLD_LIBRARY_PATH=$kaldisrc/onl-rec:$kaldisrc/pykaldi/kaldi:$openfst/lib:$openfst/lib/fst:$DYLD_LIBRARY_PATH
 export PYTHONPATH=$kaldisrc/pykaldi:$kaldisrc/pykaldi/pyfst:$PYTHONPATH
 
 beam=16.0

--- a/src/pykaldi/Makefile
+++ b/src/pykaldi/Makefile
@@ -20,6 +20,11 @@ ADDLIBS = ../onl-rec/onl-rec.a ../decoder/kaldi-decoder.a \
 		../fstext/kaldi-fstext.a ../tree/kaldi-tree.a ../matrix/kaldi-matrix.a \
 		../feat/kaldi-feat.a ../util/kaldi-util.a ../base/kaldi-base.a
 
+ifeq ($(shell uname),Darwin)
+	LINKER_OPTIONS=-Wl,-all_load $^
+else
+	LINKER_OPTIONS=-Wl,-soname=lib$(LIBNAME).so,--whole-archive $^ -Wl,--no-whole-archive
+endif
 
 
 # ifeq ($(KALDI_FLAVOR), dynamic)
@@ -28,7 +33,7 @@ LIBFILE=kaldi/lib$(LIBNAME).so
 $(LIBFILE): $(ADDLIBS)
 	# Building shared library from static librariess.
 	# The static libraries were compiled with -fPIC.
-	$(CXX) -shared -DPIC -o $@ -Wl,-soname=lib$(LIBNAME).so,--whole-archive $^ -Wl,--no-whole-archive $(EXTRA_LDLIBS) $(LDFLAGS) $(LDLIBS)
+	$(CXX) -shared -DPIC -o $@ $(LINKER_OPTIONS) $(EXTRA_LDLIBS) $(LDFLAGS) $(LDLIBS)
 # else
 # # TODO
 # # static compilation


### PR DESCRIPTION
Ondrej Platek emailed me some instructions on building pykaldi and getting the demo of online recognition running. In the process of building pykaldi on my Mac, I ran across a couple issues that had to be resolved. They are related to different behavior of the linker and a different environmental variable for the path for shared libraries on OS X.
